### PR TITLE
ci: restore PyPI token publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   github-release:
     name: Publish GitHub Release


### PR DESCRIPTION
PyPI project has no trusted-publisher entry registered, so OIDC-only publish fails with `invalid-publisher`. Restores `PYPI_API_TOKEN` auth for the publish step while keeping attestations and the pinned action. Unblocks the v1.4.4 release.

## Summary by Sourcery

Restore token-based PyPI publishing to unblock package releases.

Bug Fixes:
- Restore PyPI token authentication so release publishing succeeds when trusted-publisher authentication is unavailable.

CI:
- Update the release workflow to publish packages with the configured PyPI API token while retaining the pinned publishing action.